### PR TITLE
Added non Authorised View without navigation link. 

### DIFF
--- a/airplane ground control.xcodeproj/project.pbxproj
+++ b/airplane ground control.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AC01408C29B7A92400C16062 /* LogInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC01408B29B7A92400C16062 /* LogInView.swift */; };
+		AC40343029BCA52500A67C46 /* nonAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC40342F29BCA52500A67C46 /* nonAuthView.swift */; };
 		FE9EFAD129B267DE0042559B /* airplane_ground_controlApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9EFAD029B267DE0042559B /* airplane_ground_controlApp.swift */; };
 		FE9EFAD329B267DE0042559B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9EFAD229B267DE0042559B /* ContentView.swift */; };
 		FE9EFAD529B267E00042559B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE9EFAD429B267E00042559B /* Assets.xcassets */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		AC01408B29B7A92400C16062 /* LogInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInView.swift; sourceTree = "<group>"; };
+		AC40342F29BCA52500A67C46 /* nonAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = nonAuthView.swift; sourceTree = "<group>"; };
 		FE9EFACD29B267DE0042559B /* airplane ground control.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "airplane ground control.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE9EFAD029B267DE0042559B /* airplane_ground_controlApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = airplane_ground_controlApp.swift; sourceTree = "<group>"; };
 		FE9EFAD229B267DE0042559B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				FE9EFAE129B269C30042559B /* MainView.swift */,
 				AC01408B29B7A92400C16062 /* LogInView.swift */,
 				FEF95C4029B90B020043D100 /* AcceptedMainView.swift */,
+				AC40342F29BCA52500A67C46 /* nonAuthView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -196,6 +199,7 @@
 				FE9EFAD329B267DE0042559B /* ContentView.swift in Sources */,
 				FEE892AD29BC6FE200F35609 /* EmergencyNotifications.swift in Sources */,
 				FE9EFAE229B269C30042559B /* MainView.swift in Sources */,
+				AC40343029BCA52500A67C46 /* nonAuthView.swift in Sources */,
 				FEE892AF29BC705300F35609 /* NotificationCard.swift in Sources */,
 				AC01408C29B7A92400C16062 /* LogInView.swift in Sources */,
 				FE9EFAD129B267DE0042559B /* airplane_ground_controlApp.swift in Sources */,

--- a/airplane ground control/Views/nonAuthView.swift
+++ b/airplane ground control/Views/nonAuthView.swift
@@ -1,0 +1,66 @@
+//
+//  nonAuthView.swift
+//  airplane ground control
+//
+//  Created by Aditya Tyagi  on 09/03/23.
+//
+
+import SwiftUI
+
+
+struct nonAuthView: View {
+    var body: some View {
+        ZStack{
+            VStack{
+                nonAuthImage()
+                nonAuthDescription()
+                nonAuthDescription2()
+            }
+        }
+       
+    }
+}
+
+struct nonAuthView_Previews: PreviewProvider {
+    static var previews: some View {
+        nonAuthView()
+            
+    }
+}
+
+
+struct nonAuthDescription: View {
+    var body: some View {
+        Text("SORRY!!☹️").font(.custom("Chalkduster", fixedSize: 50)).multilineTextAlignment(.center).foregroundColor(.red).padding(.top, 5)
+        Text("Your email domain is not enabled for SmartPort app access for any airport. If your company operates at an airport which is using SmartPort app, please contact support@smartport.com indicating the airport you operate from.")
+            .font(.headline)
+            .multilineTextAlignment(.center)
+            .frame(width: 356, height: 300)
+            .aspectRatio(contentMode: .fit)
+            .foregroundColor(.black)
+            .padding(.top, -115)
+    }
+}
+
+struct nonAuthDescription2: View {
+    var body: some View {
+        Text("SMARTPORT✈️")
+            .font(.body)
+            // .frame(width: 356, height: 400)
+            .aspectRatio(contentMode: .fill)
+            .foregroundColor(.black)
+            .padding(.top, 170)
+    }
+}
+
+struct nonAuthImage: View {
+    var body: some View {
+        Image("nonAuthImage").resizable()
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 100, height: 100)
+            .clipped()
+            .cornerRadius(1)
+            .padding(.top, 110)
+    }
+}


### PR DESCRIPTION
#1  **Completed**✅

Attaching nonAuthView ss :
<img width="362" alt="Screenshot 2023-03-11 at 5 33 51 PM" src="https://user-images.githubusercontent.com/77538183/224483645-2f9811ff-fb40-4f70-b5f0-8a9d1ab12e15.png">

_Still there is no link between logIn page and accepted/non accepted view. Please check these variables so as to initiate Navigation Link between these `logInView`, `AcceptedMainView` and `nonAuthView` in these lines, i'm struggling with these._

```                Button(action: {
                    if self.username == storedUsername && self.PIN == storedPIN {
                        self.authenticationDidSucceed = true
                        self.authenticationDidFail = false
                    } else {
                        self.authenticationDidFail = true
                        self.authenticationDidSucceed = false
                    }
                }) {
                    LoginButtonContent()
                }
            }
```

